### PR TITLE
Build every pull request, publish only from main (story 98)

### DIFF
--- a/.github/workflows/deploy-to-github-packages.yaml
+++ b/.github/workflows/deploy-to-github-packages.yaml
@@ -1,14 +1,25 @@
 name: Publish to GitHub Packages
+# A pull request builds and tests, a push to main publishes. Both run as the job
+# 'publish', so a pull request Renovate opens gets a result like every other one - it did
+# not while this workflow only listened to pushes and ignored renovate/**.
+#
+# Publishing from main alone is the second half of it: GitHub Packages holds one
+# 1.1.1-SNAPSHOT per module, so every branch used to overwrite what main published, and a
+# consumer could resolve a set of modules which never existed in any single tree.
 "on":
+  pull_request:
   push:
-    branches-ignore:
-      - renovate/**
-      - release/**
-      - feature/wip-**
+    branches:
+      - main
 permissions:
   contents: read
   pages: write
   id-token: write
+concurrency:
+  # two pushes to main must not publish at the same time, and the later one has to finish
+  # rather than be cancelled: it carries the newer artifacts
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,7 +33,14 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
+      - name: Build and test
+        if: "${{ github.event_name == 'pull_request' }}"
+        run: mvn --batch-mode --update-snapshots install verify
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CI: false
       - name: Publish package
+        if: "${{ github.event_name == 'push' }}"
         run: mvn --batch-mode --update-snapshots deploy
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,9 @@
             <excludes>
               <exclude>**/target/**/</exclude>
               <exclude>**/node_modules/**/</exclude>
+              <!-- the workflows carry comments, and the YAML formatter round-trips
+                   through Jackson, which drops them -->
+              <exclude>**/.github/**/</exclude>
             </excludes>
             <sortPom>
               <quiet>true</quiet>
@@ -88,6 +91,9 @@
             <excludes>
               <exclude>**/target/**/</exclude>
               <exclude>**/node_modules/**/</exclude>
+              <!-- the workflows carry comments, and the YAML formatter round-trips
+                   through Jackson, which drops them -->
+              <exclude>**/.github/**/</exclude>
             </excludes>
             <flexmark/>
           </markdown>


### PR DESCRIPTION
Found while testing the new required checks: the three open Renovate pull requests carry **no checks at all**, so with `publish` required they can never merge and automerge waits for a result nobody produces.

The cause is in this workflow. It listened to `push` and ignored `renovate/**`, which was harmless until a check became required.

## What changes

- A pull request builds and tests (`install verify`), a push to `main` publishes. Both run as the job `publish`, so the name the branch ruleset requires stays the same.
- The coverage report is collected and uploaded on `main` only, as before.

## The second thing this fixes

Every branch used to `deploy` the shared `2.0.0-SNAPSHOT` into GitHub Packages, so whoever pushed last decided what the other repositories compiled against. Publishing from `main` alone removes that.

## Worth knowing

A pull request from a fork has no secrets and could not read the snapshots from GitHub Packages. Every pull request in this repository comes from one of its own branches, Renovate's included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
