### PR TITLE
Story 111: one Maven lifecycle per build, not two

### DIFF
--- a/.github/workflows/deploy-to-github-packages.yaml
+++ b/.github/workflows/deploy-to-github-packages.yaml
@@ -33,9 +33,13 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
+      # 'install' and not 'install verify': install already runs every phase verify
+      # has, so naming both made Maven walk two lifecycles per module. The tests
+      # skipped their second run, the compiler did not, and every javac warning was
+      # reported twice - once per compilation (story 111).
       - name: Build and test
         if: "${{ github.event_name == 'pull_request' }}"
-        run: mvn --batch-mode --update-snapshots install verify
+        run: mvn --batch-mode --update-snapshots install
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CI: false


### PR DESCRIPTION
The pull-request build ran `install verify`. Maven walks both lifecycles for every module: Surefire and Failsafe notice the repetition and skip their second run, the compiler does not. Every module was compiled twice, so every javac warning appeared twice in the log and twice as an annotation on the pull request, where a reviewer cannot tell two occurrences of one problem from two problems.

`install` contains every phase `verify` has, so nothing changes about what is built or tested.

Found while reading why the two removal warnings of story 110 arrived as four annotations in the Camunda 8 build. The same change is in every repository; this one has nothing else to do for stories 108 to 110, because its single test source declares no test method (`ProcessServiceTestDoubleCompileCheck` is a compile check) and it cannot depend on `test-utils` at all, being the first repository in the build order.

Prompt: `prompts/111-one-lifecycle-per-ci-build.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7HLKaJvVpdCiSYxhwHJTc