### PR TITLE
docs(spi): what the API promises about sharing and about signals

### DIFF
--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -14,7 +14,8 @@ public interface ProcessService<A> {
    * Start a new workflow.
    *
    * @param workflowAggregate The workflow-aggregate
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    */
   A startWorkflow(
       A workflowAggregate);
@@ -30,7 +31,8 @@ public interface ProcessService<A> {
    *
    * @param workflowAggregate The workflow-aggregate
    * @param messageName The message name
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    */
   default A startWorkflowByMessage(
       A workflowAggregate,
@@ -59,7 +61,8 @@ public interface ProcessService<A> {
    * values until something reads them.
    *
    * @param workflowAggregate The workflow-aggregate
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    */
   default A aggregateChanged(
       A workflowAggregate) {
@@ -90,7 +93,8 @@ public interface ProcessService<A> {
    *
    * @param workflowAggregate The workflow-aggregate
    * @param taskId The task-id reported previously
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    * @see TaskId
    */
   default A aggregateChanged(
@@ -113,11 +117,17 @@ public interface ProcessService<A> {
    * <b>The broadcast is scoped to the WORKFLOW MODULE of this service.</b> It
    * reaches every BPMS the module is deployed to - which is what keeps a broadcast
    * complete while workflows are being migrated from one BPMS to another - and
-   * every process of the module waiting for that signal. It does NOT reach other
-   * workflow modules: they are separate scopes, isolated by a tenant or by
-   * prefixed identifiers. An application wanting a signal in several modules sends
-   * it through the {@code ProcessService} of each of them; VanillaBP does not
-   * decide that for you, because which modules are meant is a business question.
+   * every process of the module waiting for that signal. An application wanting a
+   * signal in several modules sends it through the {@code ProcessService} of each of
+   * them; VanillaBP does not decide that for you, because which modules are meant is
+   * a business question.
+   * <p>
+   * How far the signal stays inside that module is what the module's
+   * name-clash-avoidance mode decides. A tenant or a prefixed signal name keeps it
+   * there; the mode {@code none} scopes nothing, so the signal reaches every
+   * subscription of that BPMS carrying the same name, whichever module it belongs to.
+   * That is the price of the mode rather than a property of signals, and the reason
+   * VanillaBP asks for a decision at startup where a module runs unscoped.
    * <p>
    * Pass the signal name as it is modelled; VanillaBP applies whatever name
    * scoping the workflow module uses, and the BPMS is addressed with the tenant
@@ -151,7 +161,8 @@ public interface ProcessService<A> {
    *
    * @param workflowAggregate The workflow-aggregate
    * @param messageName  The message name to be correlated
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    */
   A correlateMessage(
       A workflowAggregate,
@@ -170,7 +181,8 @@ public interface ProcessService<A> {
    * @param workflowAggregate  The workflow-aggregate
    * @param messageName   The message name to be correlated
    * @param correlationId The correlation-id
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    */
   A correlateMessage(
       A workflowAggregate,
@@ -182,7 +194,8 @@ public interface ProcessService<A> {
    *
    * @param workflowAggregate The workflow-aggregate
    * @param taskId       The task-id reported previously
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    * @see TaskId
    */
   A completeUserTask(
@@ -196,7 +209,8 @@ public interface ProcessService<A> {
    * @param taskId        The task-id reported previously
    * @param bpmnErrorCode The error code which can be caught in BPMN by error
    *                      boundary events
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    * @see TaskId
    */
   A cancelUserTask(
@@ -209,7 +223,8 @@ public interface ProcessService<A> {
    *
    * @param workflowAggregate The workflow-aggregate
    * @param taskId            The task-id reported previously
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    * @see TaskId
    */
   A completeTask(
@@ -223,7 +238,8 @@ public interface ProcessService<A> {
    * @param taskId        The task-id reported previously
    * @param bpmnErrorCode The error code which can be caught in BPMN by error
    *                      boundary events
-   * @return The workflow-aggregate attached to JPA
+   * @return The persisted workflow-aggregate, attached where the persistence layer
+   *         works that way (e.g. JPA)
    * @see TaskId
    */
   A cancelTask(

--- a/src/main/java/io/vanillabp/spi/service/SyncWithBPMS.java
+++ b/src/main/java/io/vanillabp/spi/service/SyncWithBPMS.java
@@ -28,14 +28,17 @@ import java.lang.annotation.Target;
  * <b>Inheritance:</b> an attribute which is annotated neither way inherits the
  * behavior of its owner - the aggregate class, respectively the attribute it
  * belongs to (nested objects and collection elements included). The outermost
- * default is the BPMS ADAPTER's: an embedded engine reading the aggregate live
- * (Camunda 7) shares nothing unless asked to, a remote engine (Camunda 8,
- * Process-Engine-API) shares everything - see your adapter's documentation.
+ * default belongs to the BPMS adapter, and every VanillaBP adapter shares
+ * everything: an aggregate carrying no annotation at all reaches its model
+ * completely, on an embedded engine as well as on a remote one. A model may
+ * therefore read the same attributes wherever it runs, which is the reason the
+ * default is not the adapter's taste.
  * <p>
- * <b>What sharing means</b> is the adapter's decision, too: a remote BPMS pushes
- * the values as process variables whenever VanillaBP talks to it on behalf of the
- * workflow, whereas an embedded engine reads the aggregate directly and writes the
- * values only as context information for operators.
+ * <b>What sharing means</b> is the same everywhere, too: the values are written as
+ * process variables whenever VanillaBP talks to the BPMS on behalf of the workflow,
+ * and the BPMS evaluates its models against those variables. An embedded engine
+ * could reach into the application instead, and Camunda 7 did until it turned out
+ * that a model written that way breaks on every remote BPMS.
  *
  * @see NoSyncWithBPMS
  */


### PR DESCRIPTION
Story 106, the part which lives in this repository: three claims of the business SPI which the code no longer holds.

- `@SyncWithBPMS` said the outermost default belongs to the adapter and that an embedded engine reads the aggregate live instead of pushing values. Story 66 ended that: every adapter shares everything and pushes process variables, which is what makes a model portable between BPMS.
- `ProcessService#sendSignal` claimed a signal does not reach other workflow modules because they are separate scopes. That holds for a tenant and for prefixed identifiers, not for the mode `none`, which scopes nothing.
- The `@return` of every operation promised an object attached to JPA, although the aggregate may live in MongoDB or in a persistence the application brought.

The full pass and its register are in the platform's pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7HLKaJvVpdCiSYxhwHJTc