### PR TITLE
The one prompt reference this repository still carried

### DIFF
--- a/.github/workflows/deploy-to-github-packages.yaml
+++ b/.github/workflows/deploy-to-github-packages.yaml
@@ -36,7 +36,7 @@ jobs:
       # 'install' and not 'install verify': install already runs every phase verify
       # has, so naming both made Maven walk two lifecycles per module. The tests
       # skipped their second run, the compiler did not, and every javac warning was
-      # reported twice - once per compilation (story 111).
+      # reported twice - once per compilation.
       - name: Build and test
         if: "${{ github.event_name == 'pull_request' }}"
         run: mvn --batch-mode --update-snapshots install


### PR DESCRIPTION
The sweep which removes story and prompt references from the sources found a single hit here: a
comment in the publish workflow explaining why a warning is reported twice named the story which
fixed it. The sentence stands without that pointer, so the pointer is gone.

Rule behind it: the prompts are neither public nor permanent, and a story number cites a
decision as it stood back then, which a later change can overturn without anything noticing. The
sanctioned citation target is a numbered entry in this repository's own `README.md` decision log.
Nothing here cites one yet, so there is no log to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)