### PR TITLE
The promises this API makes are a decision log the code can cite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Working on spi-for-java
+
+The API a business application writes against. Every change here is visible to applications, so
+additive is the default and a removal needs a deprecation which names the release it goes out in.
+
+Read [`README.md`](./README.md) first. Its anchors are linked from the blueprints and from the
+wikis, so a heading is renamed only together with everything pointing at it.
+
+## The decision log is binding
+
+[`DECISIONS.md`](./DECISIONS.md) holds the decisions several places in this repository rely on. It
+is the ONLY thing the code is allowed to cite, in the plain greppable form
+`see decision 7 in the repository's DECISIONS.md`, and only entries of THIS repository.
+
+Read it before you change behaviour. An entry is not background reading, it is the reason the code
+around it looks the way it does, so a change which contradicts one is wrong until the entry says
+otherwise.
+
+**A decision is changed or replaced only after asking.** Where your change would make an entry
+untrue, stop and put the question to the maintainer before you write the change. If the answer is
+yes, the same commit updates the log: the old entry STAYS, marked as superseded and naming the
+entry which replaced it, and the new decision takes the next free number. Numbers are never reused
+and never renumbered, because a citation in an older release still points at them. Editing an
+entry until its old text is gone is never the way.
+
+Adding an entry has the same rule. A decision earns a number when several places rely on it and
+copying the explanation to each of them would rot; anything smaller is a comment where it belongs,
+and anything larger is documentation.
+
+## What code may point at
+
+Nothing which a later change can invalidate without anything noticing: no story or prompt number,
+no issue or pull-request number, no chat transcript, no person. Those record a conversation at a
+point in time. A decision entry lives next to the code and is overhauled in the same commit, which
+is what makes it citable.
+
+Where a name can carry the reason, the name is the better fix. Where it cannot, a comment says why
+in its own words, complete where it stands. Only what several places have to carry becomes an
+entry in the log.
+
+Commit messages and pull-request descriptions may cite whatever they like. They are records of a
+point in time themselves.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,98 @@
+# Decision log
+
+Decisions this repository's code points at. A number is handed out once and never reused or
+renumbered, so a citation stays resolvable; a decision which gets overturned keeps its entry,
+marked as superseded and naming the entry which replaced it.
+
+A citation in code reads `see decision 2 in the repository's DECISIONS.md`, and it names an entry
+of THIS repository only. What the platform integration or a BPMS adapter makes of a decision has
+its own entry in that repository, written from that side; a pointer into another repository is the
+fragile kind this log exists to avoid.
+
+This is the API a business application writes against, so every entry here is a promise to that
+application rather than an implementation note. The detail belongs in
+[`README.md`](./README.md) and in the
+[wiki](https://github.com/vanillabp/spi-for-java/wiki), which an entry may link.
+
+### 1. The workflow aggregate is the state of a workflow, and the only state there is
+
+A workflow does not keep data in the BPMS. It keeps it in an entity of the application, the
+workflow aggregate, which the application owns, persists and queries with its own tools, and
+VanillaBP hands to every handler of that workflow. Process variables are not part of this API.
+
+That is what makes a workflow debuggable with the application's own means, and it is what makes a
+model portable: an expression which needs a value reads it from what the aggregate SHARES rather
+than from something a particular engine happens to hold. It also decides the failure mode. Because
+the aggregate is written in the same transaction as everything else the handler did, a rollback
+undoes the business change and the workflow step together.
+
+### 2. A workflow is addressed by the identifier the business already has
+
+There is no technical workflow id in this API. The id attribute of the aggregate is what addresses
+the workflow, from `startWorkflow` to every later operation, so an application which already knows
+a loan request by its number keeps using that number.
+
+The consequence a caller feels is that an id has to exist before a workflow starts, and that it
+has to be stable. A generated key which the persistence hands out on flush is fine; a value the
+business changes later is not, because the BPMS remembers the one it was given.
+See [Natural ids](./README.md#natural-ids).
+
+### 3. What the BPMS gets to see is declared, not guessed
+
+`@SyncWithBPMS` and `@NoSyncWithBPMS` say which values of an aggregate travel to the BPMS, on the
+class, on an attribute or on a nested type, with the more specific one winning. The default is the
+adapter's, which is why an aggregate without any annotation behaves the way its BPMS needs.
+
+Declaring it is what keeps a model portable. An engine which runs embedded could read the
+aggregate live and an application which relies on that works on that engine and takes the wrong
+branch on every remote one, silently. Declaring it is also what keeps the payload honest: a value
+which nothing in the model reads has no reason to leave the application.
+
+### 4. A `TaskException` is a business outcome, not a failure
+
+A handler which throws `TaskException` has not failed. It reports a result the model has an error
+boundary for, so the workflow takes that path and the aggregate is COMMITTED on the way out.
+Every other exception is a technical failure: nothing is committed and the BPMS retries.
+
+Which of the two happened is therefore a decision the model and the handler make together, and
+this is why a workflow service must not carry a transaction of its own. VanillaBP holds the
+transaction and needs a `TaskException` not to roll it back; an application-side `@Transactional`
+which joins would mark it rollback-only and turn a modelled outcome into an incident. The
+startup check reports that before the first workflow runs.
+
+### 5. A method serves a version range of a deployed process, not a business version
+
+`version` on `@WorkflowTask`, `@WorkflowStartedByBpms` and `@WorkflowEnded` names versions of the
+DEPLOYED process definition as the BPMS counts them, or a version tag of the model. It exists
+because a BPMS keeps every version it was ever given and workflows keep running on the old ones
+while the application only brings the newest model with it.
+
+Two rules follow, and both are checked while the application boots. Ranges of one task must not
+overlap, or a delivery would be served by an arbitrary one of two candidates. And a delivery whose
+version the BPMS does not report is served only by a method WITHOUT a range, so a method which
+names versions never runs on a delivery nobody could match.
+See [Versioning of BPMN business-processes](./README.md#versioning-of-bpmn-business-processes).
+
+### 6. A signal is a broadcast within one workflow module
+
+`sendSignal` has no instance-addressed variant, on purpose: a signal in BPMN is a broadcast, and
+an application which wants to reach ONE workflow has `correlateMessage`, which is addressed by the
+aggregate. What the broadcast reaches is the workflow module of the `ProcessService` it was sent
+through, across its processes and not across module boundaries.
+
+Which modules are meant is a business question, so an application which needs a signal in several
+of them sends it through the `ProcessService` of each. A signal carries no payload either, for the
+same reason a correlated message carries none: what the workflow needs is in its aggregate.
+See [Broadcast a signal](./README.md#broadcast-a-signal).
+
+### 7. An asynchronous task is a task which keeps its id
+
+A handler taking a `@TaskId` tells VanillaBP that the workflow stays in this task after the method
+returns, and that the application will complete or cancel it later by that id. A handler without
+one is done when it returns.
+
+That single parameter is what an adapter needs to know at wiring time, which is why a
+contradiction between it and the model is reported while the application boots rather than as an
+incident on a live workflow. The same id is what a user task is completed by, so both kinds of
+waiting look the same to the application.
+See [User tasks and asynchronous tasks](./README.md#user-tasks-and-asynchronous-tasks).

--- a/README.md
+++ b/README.md
@@ -880,6 +880,15 @@ A domain aggregate is used as a persistent entity to store data either required 
 
 If particular attributes are required often (e.g. nearly every task) then this aggregate can be used as a *cache* of the original source of data. Depending on the use-case one might has to implement a proper update strategy.
 
+## Decision log
+
+Decisions several places in this repository rely on live in [`DECISIONS.md`](./DECISIONS.md), the
+one thing the code is allowed to cite. A citation reads `see decision 2 in the repository's
+DECISIONS.md`, numbers are never reused, and an overturned entry stays and names its successor, so
+a citation written today still resolves in a year. The entries are the promises this API makes to
+an application: where the state of a workflow lives, what addresses it, what the BPMS gets to see,
+and what an exception out of a handler means.
+
 ## Noteworthy & Contributors
 
 VanillaBP was developed by [Phactum](https://www.phactum.at) with the intention of giving back to the community as it has benefited the community in the past.

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -6,6 +6,12 @@ import java.util.List;
 import io.vanillabp.spi.service.TaskId;
 
 /**
+ * <p>
+ * Two promises of this interface are written down where several places rely on them: a workflow is
+ * addressed by the id attribute of its aggregate rather than by a technical key (decision 2 in the
+ * repository's DECISIONS.md), and a broadcast signal reaches the workflow module of THIS service
+ * and no other (decision 6 in the repository's DECISIONS.md).
+ *
  * @param <A> The workflow-aggregate-class
  */
 public interface ProcessService<A> {

--- a/src/main/java/io/vanillabp/spi/service/NoSyncWithBPMS.java
+++ b/src/main/java/io/vanillabp/spi/service/NoSyncWithBPMS.java
@@ -26,6 +26,9 @@ import java.lang.annotation.Target;
  * <b>Inheritance:</b> like {@link SyncWithBPMS} the annotation applies to the
  * annotated element AND everything below it (a nested object's attributes, a
  * collection's elements) until an inner element says otherwise.
+ * <p>
+ * Why what a BPMS gets to see is declared rather than derived is decision 3 in the repository's
+ * DECISIONS.md.
  *
  * @see SyncWithBPMS
  */

--- a/src/main/java/io/vanillabp/spi/service/SyncWithBPMS.java
+++ b/src/main/java/io/vanillabp/spi/service/SyncWithBPMS.java
@@ -39,6 +39,9 @@ import java.lang.annotation.Target;
  * and the BPMS evaluates its models against those variables. An embedded engine
  * could reach into the application instead, and Camunda 7 did until it turned out
  * that a model written that way breaks on every remote BPMS.
+ * <p>
+ * Why what a BPMS gets to see is declared rather than derived, and what that has to do with running
+ * the same model on another BPMS, is decision 3 in the repository's DECISIONS.md.
  *
  * @see NoSyncWithBPMS
  */

--- a/src/main/java/io/vanillabp/spi/service/TaskException.java
+++ b/src/main/java/io/vanillabp/spi/service/TaskException.java
@@ -2,6 +2,10 @@ package io.vanillabp.spi.service;
 
 /**
  * Used to indicate errors which have to be processed by the BPMN.
+ * <p>
+ * Why this is a business outcome with the aggregate committed, and not a failure, is decision 4 in
+ * the repository's DECISIONS.md. That decision is also why a workflow service must not carry a
+ * transaction of its own.
  */
 public class TaskException extends RuntimeException {
 

--- a/src/main/java/io/vanillabp/spi/service/TaskId.java
+++ b/src/main/java/io/vanillabp/spi/service/TaskId.java
@@ -31,6 +31,9 @@ import io.vanillabp.spi.process.ProcessService;
  * {@link ProcessService#cancelUserTask(Object, String, String)} for user-tasks
  * or {@link ProcessService#completeTask(Object, String)} or
  * {@link ProcessService#cancelTask(Object, String, String)} for workflow-tasks.
+ * <p>
+ * Why this one parameter is what makes a task asynchronous, and why a contradiction with the model
+ * is reported while the application boots, is decision 7 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
@@ -32,6 +32,8 @@ import java.lang.annotation.Target;
  * it runs in the transaction ending the workflow depends on the BPMS: an embedded
  * engine ends the workflow and calls the method in ONE transaction, a remote BPMS
  * delivers the notification afterwards.
+ * <p>
+ * What the version range names is decision 5 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/src/main/java/io/vanillabp/spi/service/WorkflowService.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowService.java
@@ -10,6 +10,9 @@ import java.lang.annotation.Target;
 
 /**
  * Used to wire workflow-services to the processes they are responsible for.
+ * <p>
+ * Where the state of a workflow lives, and why that is the aggregate rather than a process
+ * variable, is decision 1 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(TYPE)

--- a/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
@@ -42,6 +42,8 @@ import java.lang.annotation.Target;
  * transaction VanillaBP opened for the start; the aggregate is saved afterwards.
  * Throwing means the workflow does not start: the aggregate is rolled back and the
  * BPMS applies its retry semantics.
+ * <p>
+ * What the version range names is decision 5 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
@@ -17,6 +17,9 @@ import java.lang.annotation.Target;
  * &#64;WorkflowTask(taskDefinition = "doSomeWorkload")
  * public void doSomeWorkload(final MyWorkflowAggregate aggregate) throws {@link TaskException} {
  * </pre>
+ * <p>
+ * What the version range names, and why a delivery without a reported version is served only by a
+ * method without one, is decision 5 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)


### PR DESCRIPTION
`DECISIONS.md`, seven entries, derived from the implemented prompts and cited from the code. No behaviour change: Javadoc, Markdown, nothing else.

This repository had no log at all, because the inventory of the self-explaining-code story found no story references here. It does hold decisions, though: they are the promises this API makes to an application, and until now nothing wrote them down.

| # | entry |
|---|---|
| 1 | The workflow aggregate is the state of a workflow, and the only state there is |
| 2 | A workflow is addressed by the identifier the business already has |
| 3 | What the BPMS gets to see is declared, not guessed |
| 4 | A `TaskException` is a business outcome, not a failure |
| 5 | A method serves a version range of a deployed process, not a business version |
| 6 | A signal is a broadcast within one workflow module |
| 7 | An asynchronous task is a task which keeps its id |

Cited from `ProcessService`, `TaskException`, `WorkflowService`, `SyncWithBPMS`, `NoSyncWithBPMS`, `TaskId` and the three version-carrying annotations, in the form `see decision 2 in the repository's DECISIONS.md`. Every entry is cited, every citation resolves, both checked mechanically.

`AGENTS.md` is new and says the rule an agent has to keep: the log is binding, and **an entry is changed or replaced only after asking**. Superseded rather than edited away, number kept, successor takes the next free one, because a citation written into code is read years later and sometimes from a release which is no longer built here.

`README.md` gained a pointer section. Its anchors are load-bearing (the blueprints and the wikis link them), so nothing existing was renamed.

**Proof:** `mvn -o install` green, spotless included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)