### PR TITLE
@BpmnProcess carries the version range of a whole class

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -62,6 +62,9 @@ startup check reports that before the first workflow runs.
 
 ### 5. A method serves a version range of a deployed process, not a business version
 
+*Superseded by decision 8, which adds `@BpmnProcess` as the fourth annotation carrying a version and
+says what a method inheriting a range promises.*
+
 `version` on `@WorkflowTask`, `@WorkflowStartedByBpms` and `@WorkflowEnded` names versions of the
 DEPLOYED process definition as the BPMS counts them, or a version tag of the model. It exists
 because a BPMS keeps every version it was ever given and workflows keep running on the old ones
@@ -96,3 +99,28 @@ contradiction between it and the model is reported while the application boots r
 incident on a live workflow. The same id is what a user task is completed by, so both kinds of
 waiting look the same to the application.
 See [User tasks and asynchronous tasks](./README.md#user-tasks-and-asynchronous-tasks).
+
+### 8. A version range is declared per method or per workflow service class
+
+`@BpmnProcess(version = ...)` is the fallback of `@WorkflowTask`, `@WorkflowStartedByBpms` and
+`@WorkflowEnded`. A method naming no version serves the range of the process it was declared with, a
+method naming one keeps it word by word, and the two are never intersected. So a class holding the
+handlers of one generation of a model says that once, where decision 5 left it saying the same thing
+once per method - and where a method added later without the attribute silently served every version.
+
+The attribute has been on `@BpmnProcess` since version 1 and nothing read it. Giving it this meaning
+is what makes it documentable, and it is a promise to an application which wrote it back then
+believing it worked: the platform's `UPGRADE.md` says what such an application has to check.
+
+Two rules of decision 5 hold unchanged for the range a method ends up with, whichever annotation it
+came from. Ranges of one BPMN element must not overlap, which now also holds for two classes
+declaring the same process, the shape this exists for and legal as long as their ranges are
+disjoint. And a delivery whose version the BPMS does not report is served only by a method WITHOUT a
+range: a method which inherits one is restricted, so serving such a delivery needs a method whose
+class names no version either. Every message about a range names the declaration it came from, since
+the method it complains about may carry no attribute at all.
+
+Which declaration applies is decided by the process a delivery came from, not by the class: a class
+declares one `bpmnProcess` plus any number of `secondaryBpmnProcesses`, each with a version of its
+own, and one method may serve elements of both.
+See [Versioning of BPMN business-processes](./README.md#versioning-of-bpmn-business-processes).

--- a/README.md
+++ b/README.md
@@ -586,7 +586,39 @@ The same attribute exists on `@WorkflowStartedByBpms` and `@WorkflowEnded` and m
 
 Two things are worth knowing. Several methods may serve one BPMN element as long as their versions do not overlap;
 overlapping specifications are a mistake VanillaBP reports when the application starts, naming both methods. And a
-BPMS which does not report the version of a process serves only methods without a version specification. See the
+BPMS which does not report the version of a process serves only methods without a version specification.
+
+Where a change is big enough that a whole class of handlers belongs to the old model, declare the range on the
+process instead of on every method. `@BpmnProcess(version = ...)` is the fallback of all three method annotations:
+
+```java
+@Component
+@WorkflowService(
+        workflowAggregateClass = LoanApproval.class,
+        bpmnProcess = @BpmnProcess(bpmnProcessId = "loan_approval", version = "<10"))
+public class LoanApprovalUpToTen {
+
+  @WorkflowTask                      // serves versions below 10
+  public void retrieveCreditRating(
+          final LoanApproval loanApproval) { ... }
+
+  @WorkflowTask(version = "5-7")     // its own range, which the class does not narrow
+  public void assessRisk(
+          final LoanApproval loanApproval) { ... }
+
+}
+```
+
+A method naming its own range keeps it word by word, even where it reaches outside the range of its class: the two
+are not intersected, because a range you cannot read off the annotation in front of you is worse than one repeated.
+Every declaration carries its own version, the entries of `secondaryBpmnProcesses` included, so a method serving
+elements of two processes inherits per process. Two classes may declare the same process, which is what this is for -
+one per generation of the model - as long as their ranges are disjoint.
+
+Mind the one surprise: a method which INHERITS a range is as restricted as one naming it, so a BPMS which reports no
+version reaches neither. Serving such a delivery needs a method whose class names no version either.
+
+See the
 [adapter platform's wiki](https://github.com/vanillabp/adapter-platform-integration/wiki/Workflow-tasks#versions-of-a-process)
 for what each BPMS can tell, and the blueprint [`bpmn-versioning`](https://github.com/vanillabp-blueprints/bpmn-versioning-springboot)
 for a model changed under running workflows.

--- a/src/main/java/io/vanillabp/spi/service/BpmnProcess.java
+++ b/src/main/java/io/vanillabp/spi/service/BpmnProcess.java
@@ -28,19 +28,42 @@ public @interface BpmnProcess {
   String bpmnProcessId() default BpmnProcess.USE_CLASS_NAME;
 
   /**
-   * Can be used to define certain versions or ranges of versions of a process for
-   * which the annotated type should be used for.
+   * Which versions of this deployed BPMN process the annotated class serves. It is the
+   * FALLBACK of {@link WorkflowTask#version()}, {@link WorkflowStartedByBpms#version()}
+   * and {@link WorkflowEnded#version()}: a method of this class naming no version of its
+   * own serves the range declared here, so a class holding the handlers of one generation
+   * of a model states that once instead of once per method. A method naming its own range
+   * keeps it word by word - the range declared here does not narrow it.
    * <p>
-   * Format:
+   * The version is the version of the process DEFINITION as the BPMS counts it (Camunda 7
+   * and Camunda 8 count integers upwards per BPMN process id), not a version the
+   * application invents. A boundary is either such a version or a version TAG given in
+   * the model (<code>camunda:versionTag</code> in Camunda 7, <code>zeebe:versionTag</code>
+   * in Camunda 8):
    * <ul>
-   * <li><i>*</i>: all versions
-   * <li><i>1</i>: only version &quot;1&quot;
-   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
-   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
-   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * <li><i>*</i>: every version (the default)
+   * <li><i>3</i> or <i>release-2024</i>: exactly that version, respectively every version
+   * carrying that tag
+   * <li><i>1-3</i> or <i>v1.0..v2.0</i>: a range, both boundaries included
+   * <li><i>&gt;3</i>, <i>&gt;=3</i>, <i>&lt;v2.0</i>, <i>&lt;=v2.0</i>: open ended, the
+   * boundary excluded respectively included</li>
    * </ul>
+   * Ranges accept <code>..</code> as well as <code>-</code> as their separator; a boundary
+   * naming a tag which contains a <code>-</code> has to use <code>..</code>.
+   * &quot;Greater&quot; and &quot;less&quot; mean the deployment order, which for a BPMS
+   * counting versions upwards is the numeric order.
+   * <p>
+   * Two classes may declare the same BPMN process, which is what this attribute is for -
+   * one per generation of the model. Their ranges must not overlap; overlapping ones are
+   * reported when the application starts. Every declaration carries its own version, the
+   * entries of <code>secondaryBpmnProcesses</code> included, and a method serving elements
+   * of two processes inherits per process.
+   * <p>
+   * A method which INHERITS a range is as restricted as one naming it, so it does not serve
+   * a delivery whose version the BPMS did not report - see decision 8 in the repository's
+   * DECISIONS.md.
    *
-   * @return The version of the process this method belongs to
+   * @return The versions of this deployed BPMN process the annotated class serves
    */
   String[] version() default ALL_VERSIONS;
 

--- a/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
@@ -33,7 +33,9 @@ import java.lang.annotation.Target;
  * engine ends the workflow and calls the method in ONE transaction, a remote BPMS
  * delivers the notification afterwards.
  * <p>
- * What the version range names is decision 5 in the repository's DECISIONS.md.
+ * What the version range names, why a delivery without a reported version is served only by a
+ * method without one, and how a method naming none takes the range of its
+ * {@link BpmnProcess}, is decision 8 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)
@@ -76,6 +78,10 @@ public @interface WorkflowEnded {
    * A BPMS which does not report the version of a process serves every method
    * regardless of this attribute, and specifications naming a version tag need a
    * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
+   * <p>
+   * Naming no version does not mean &quot;every version&quot; unconditionally: the method
+   * then serves the range of the {@link BpmnProcess} its process was declared with, which
+   * is how a whole workflow service class is bound to one generation of a model.
    *
    * @return The versions of the deployed BPMN process this method serves.
    */

--- a/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
@@ -43,7 +43,9 @@ import java.lang.annotation.Target;
  * Throwing means the workflow does not start: the aggregate is rolled back and the
  * BPMS applies its retry semantics.
  * <p>
- * What the version range names is decision 5 in the repository's DECISIONS.md.
+ * What the version range names, why a delivery without a reported version is served only by a
+ * method without one, and how a method naming none takes the range of its
+ * {@link BpmnProcess}, is decision 8 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)
@@ -86,6 +88,10 @@ public @interface WorkflowStartedByBpms {
    * A BPMS which does not report the version of a process serves every method
    * regardless of this attribute, and specifications naming a version tag need a
    * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
+   * <p>
+   * Naming no version does not mean &quot;every version&quot; unconditionally: the method
+   * then serves the range of the {@link BpmnProcess} its process was declared with, which
+   * is how a whole workflow service class is bound to one generation of a model.
    *
    * @return The versions of the deployed BPMN process this method serves.
    */

--- a/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
@@ -18,8 +18,9 @@ import java.lang.annotation.Target;
  * public void doSomeWorkload(final MyWorkflowAggregate aggregate) throws {@link TaskException} {
  * </pre>
  * <p>
- * What the version range names, and why a delivery without a reported version is served only by a
- * method without one, is decision 5 in the repository's DECISIONS.md.
+ * What the version range names, why a delivery without a reported version is served only by a
+ * method without one, and how a method naming none takes the range of its
+ * {@link BpmnProcess}, is decision 8 in the repository's DECISIONS.md.
  */
 @Retention(RUNTIME)
 @Target(METHOD)
@@ -67,6 +68,10 @@ public @interface WorkflowTask {
    * A BPMS which does not report the version of a process serves every method
    * regardless of this attribute, and specifications naming a version tag need a
    * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
+   * <p>
+   * Naming no version does not mean &quot;every version&quot; unconditionally: the method
+   * then serves the range of the {@link BpmnProcess} its process was declared with, which
+   * is how a whole workflow service class is bound to one generation of a model.
    *
    * @return The versions of the deployed BPMN process this method serves.
    */


### PR DESCRIPTION
`@BpmnProcess.version()` has existed since version 1 and nothing ever read it. It becomes the fallback of `@WorkflowTask`, `@WorkflowStartedByBpms` and `@WorkflowEnded`, so a class holding the handlers of one generation of a model declares the range once instead of once per method. The implementation lives in `adapter-platform-integration`; this repository carries the API and its documentation.

What changed here:

- the Javadoc of `@BpmnProcess.version()`, which still documented the version 1 format (`*`, `1`, `1-3`, `>3`, `<3`), is in line with the other three annotations now and says what a method inherits;
- the three method annotations say that naming no version does not mean "every version" unconditionally;
- `README.md`, section "Versioning of BPMN business-processes", gains the fallback with an example, the rule that the method's own range is never narrowed, and the surprise that an inherited range restricts as much as one written on the method;
- `DECISIONS.md`: decision 5 is marked superseded and decision 8 states the fallback. Asked and agreed before writing.

Build green, anchors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)