### PR TITLE
docs(spi): secondaryBpmnProcesses is also how a renamed process stays served

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,23 @@ one per generation of the model - as long as their ranges are disjoint.
 Mind the one surprise: a method which INHERITS a range is as restricted as one naming it, so a BPMS which reports no
 version reaches neither. Serving such a delivery needs a method whose class names no version either.
 
+Renaming the BPMN process itself is the one refactoring which reaches into the BPMS, and it is the second reason
+`secondaryBpmnProcesses` exists. The old id stays in the BPMS with every version ever deployed under it and with the
+workflows still running on them, so name it as a secondary process together with the versions the BPMS still holds
+under it, and the methods of your class keep serving those workflows until the last of them ends:
+
+```java
+@WorkflowService(
+        workflowAggregateClass = OrderApproval.class,
+        bpmnProcess = @BpmnProcess(bpmnProcessId = "OrderApproval"),
+        secondaryBpmnProcesses = @BpmnProcess(bpmnProcessId = "order_approval", version = "1-3"))
+```
+
+Each id is counted from 1 by the BPMS, so the versions of the old id and of the new one are different models with the
+same numbers. The
+[recipe for a rename](https://github.com/vanillabp/adapter-platform-integration/wiki/Renaming-a-BPMN-process)
+walks through it, including what the application says on the next boot.
+
 See the
 [adapter platform's wiki](https://github.com/vanillabp/adapter-platform-integration/wiki/Workflow-tasks#versions-of-a-process)
 for what each BPMS can tell, and the blueprint [`bpmn-versioning`](https://github.com/vanillabp-blueprints/bpmn-versioning-springboot)

--- a/src/main/java/io/vanillabp/spi/service/WorkflowService.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowService.java
@@ -34,8 +34,32 @@ public @interface WorkflowService {
   BpmnProcess bpmnProcess() default @BpmnProcess(bpmnProcessId = BpmnProcess.USE_CLASS_NAME);
 
   /**
-   * @return Any additional process definition ids as defined in the BPMN for which the
-   *         annotated service is responsible for.
+   * Any further BPMN processes the annotated service is responsible for. A process called by
+   * a call activity of the primary one is the common case, and a process which was RENAMED is
+   * the second.
+   * <p>
+   * Renaming a BPMN process is the one refactoring which reaches into the BPMS: the old id
+   * stays there with every version ever deployed under it and with the workflows still
+   * running on them, while the software brings only the new name. Naming the old id here,
+   * with the {@link BpmnProcess#version()} of the versions the BPMS still holds under it,
+   * keeps those workflows served by the methods of this class:
+   *
+   * <pre>
+   * &#64;WorkflowService(
+   *         workflowAggregateClass = OrderApproval.class,
+   *         bpmnProcess = &#64;BpmnProcess(bpmnProcessId = "OrderApproval"),
+   *         secondaryBpmnProcesses = &#64;BpmnProcess(bpmnProcessId = "order_approval", version = "1-3"))
+   * </pre>
+   *
+   * Each entry is a declaration of its own and carries its own version range. Mind what that
+   * means for a rename: a BPMS counts the versions of each process id separately, so version 2
+   * of the old id and version 2 of the new one are different models, and a range naming numbers
+   * belongs to the declaration it stands on rather than to the class.
+   * <p>
+   * A workflow is STARTED under {@link #bpmnProcess()} only. A secondary process serves what is
+   * already running, and the workflows of the old id end under it.
+   *
+   * @return The further BPMN process definition ids the annotated service is responsible for
    */
   BpmnProcess[] secondaryBpmnProcesses() default {};
 }


### PR DESCRIPTION
## What changed

The javadoc of `secondaryBpmnProcesses` said what the attribute takes and left the second reason it
exists unsaid. Renaming a BPMN process is the one refactoring which reaches into the BPMS: the old
`bpmnProcessId` stays there with every version ever deployed under it and with the workflows still
running on them, while the software brings only the new name. Naming the old id as a secondary
process, with the versions the BPMS still holds under it, is how those workflows keep being served
by the methods of the same class - and it is what the platform's startup check now reads (see
adapter-platform-integration#138).

Two things a reader has to know travel with it: each BPMN process id is counted from 1 by the BPMS,
so a numeric range belongs to the declaration it stands on rather than to the class, and a workflow
is STARTED under the primary declaration only.

The versioning chapter of `README.md` gets the same in the words a user reads first, with a link to
the recipe on the platform's wiki.

Javadoc and README only, no code.

## What I tested

`mvn install` of this repository (nothing here has behaviour to test); the behaviour the sentences
promise is held by `RenamedBpmnProcessTest` in adapter-platform-integration and by
`Camunda8RenamedProcessIT` in the Camunda 8 adapter.

## Claims

wiki pages re-read: the platform's `Workflow-tasks` (versions of a process) and the new
`Renaming-a-BPMN-process`, both of which this repository's README now links.
